### PR TITLE
Fix resources recreated every data.json harvest

### DIFF
--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -61,7 +61,7 @@ class DCATHarvester(HarvesterBase):
 
 
             log.debug('Getting file %s', url)
-            
+
             # get the `requests` session object
             session = requests.Session()
             for harvester in p.PluginImplementations(IDCATRDFHarvester):
@@ -220,6 +220,28 @@ class DCATHarvester(HarvesterBase):
         else:
             self.config = {}
 
+    def _get_existing_dataset(self, guid):
+        '''
+        Checks if a dataset with a certain guid extra already exists
+
+        Returns a dict as the ones returned by package_show
+        '''
+
+        datasets = model.Session.query(model.Package.id) \
+                                .join(model.PackageExtra) \
+                                .filter(model.PackageExtra.key == 'guid') \
+                                .filter(model.PackageExtra.value == guid) \
+                                .filter(model.Package.state == 'active') \
+                                .all()
+
+        if not datasets:
+            return None
+        elif len(datasets) > 1:
+            log.error('Found more than one dataset with the same guid: {0}'
+                      .format(guid))
+
+        return p.toolkit.get_action('package_show')({}, {'id': datasets[0][0]})
+
     def validate_config(self, config):
         if not config:
             return config
@@ -268,7 +290,6 @@ class DCATHarvester(HarvesterBase):
 
     def gather_stage(self,harvest_job):
         log.debug('In DCATHarvester gather_stage')
-
 
         ids = []
 
@@ -380,6 +401,7 @@ class DCATHarvester(HarvesterBase):
 
     def import_stage(self,harvest_object):
         log.debug('In DCATHarvester import_stage')
+
         if not harvest_object:
             log.error('No harvest object received')
             return False
@@ -421,6 +443,20 @@ class DCATHarvester(HarvesterBase):
 
         if not package_dict.get('name'):
             package_dict['name'] = self._get_package_name(harvest_object, package_dict['title'])
+
+        # copy across resource ids from the existing dataset, otherwise they'll
+        # be recreated with new ids
+        if status== 'change':
+            existing_dataset = self._get_existing_dataset(harvest_object.guid)
+            if existing_dataset:
+                # check if resources already exist based on their URL
+                existing_resources =  existing_dataset.get('resources')
+                resource_mapping = {r.get('url'): r.get('id')
+                                    for r in existing_resources}
+                for resource in package_dict.get('resources'):
+                    res_url = resource.get('url')
+                    if res_url and res_url in resource_mapping:
+                        resource['id'] = resource_mapping[res_url]
 
         # Allow custom harvesters to modify the package dict before creating
         # or updating the package

--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -66,27 +66,6 @@ class DCATRDFHarvester(DCATHarvester):
 
         return guid
 
-    def _get_existing_dataset(self, guid):
-        '''
-        Checks if a dataset with a certain guid extra already exists
-
-        Returns a dict as the ones returned by package_show
-        '''
-
-        datasets = model.Session.query(model.Package.id) \
-                                .join(model.PackageExtra) \
-                                .filter(model.PackageExtra.key=='guid') \
-                                .filter(model.PackageExtra.value==guid) \
-                                .filter(model.Package.state=='active') \
-                                .all()
-
-        if not datasets:
-            return None
-        elif len(datasets) > 1:
-            log.error('Found more than one dataset with the same guid: {0}'.format(guid))
-
-        return p.toolkit.get_action('package_show')({}, {'id': datasets[0][0]})
-
     def _mark_datasets_for_deletion(self, guids_in_source, harvest_job):
         '''
         Given a list of guids in the remote source, checks which in the DB


### PR DESCRIPTION
With this PR, data.json harvester updates any existing resources, rather than deleting and creating new ones every harvest.

This is a straight port of the same code in https://github.com/ckan/ckanext-dcat/pull/94.

Fixes https://github.com/ckan/ckanext-dcat/issues/91 for data.json.