### PR TITLE
[OD-1100] Remove language field

### DIFF
--- a/ckanext/dcat/converters.py
+++ b/ckanext/dcat/converters.py
@@ -44,10 +44,10 @@ def dcat_to_ckan(dcat_dict):
         package_dict['extras'].append({'key': 'dcat_publisher_name', 'value': dcat_publisher.get('name')})
         package_dict['extras'].append({'key': 'dcat_publisher_email', 'value': dcat_publisher.get('mbox')})
 
-    package_dict['extras'].append({
-        'key': 'language',
-        'value': ','.join(dcat_dict.get('language', []))
-    })
+    #package_dict['extras'].append({
+    #    'key': 'language',
+    #    'value': ','.join(dcat_dict.get('language', []))
+    #})
 
     package_dict['resources'] = []
     for distribution in dcat_dict.get('distribution', []):

--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -226,9 +226,12 @@ class DCATHarvester(HarvesterBase):
         contact_point_mapping = self.config.get('contact_point',[])
         if contact_point_mapping:
             contactPoint = dcat_dict.get('contactPoint',{})
-            if contactPoint:
-                contactPointName = contactPoint.get('fn')
-                contactPointEmail = contactPoint.get('hasEmail',':').split(':')[1]
+            # try to get name and email from data catalog
+            # use default name or email if either is missing
+            contactPointName = contactPoint.get('fn') or \
+                               contact_point_mapping.get('default_name')
+            contactPointEmail = contactPoint.get('hasEmail',':').split(':')[1] or \
+                                contact_point_mapping.get('default_email')
             for key in contact_point_mapping:
                 if contact_point_mapping[key] and key == 'name_field':
                     package_dict[contact_point_mapping[key]] = contactPointName


### PR DESCRIPTION
## [Ticket](https://opengovinc.atlassian.net/browse/OD-1100)

## Description
The dcat harvest extension adds the language metadata field to the dataset extras field. If a custom schema also has language as a metadata field this will cause an issue.

A metadata field can not be both in the dataset metadata and the dataset extras metadata.

This PR also sets a default name or email if it is missing from a data.json like https://data.debtwatch.treasurer.ca.gov/data.json

## Testing
- Install the dcat json harvester and checkout this PR.
- Install a custom schema with language as a metadata field like cademo 
  https://github.com/OpenGov-OpenData/ckanext-custom-schema/tree/cademo
- Restart the supervisor service
  `sudo service supervisor restart`
- Harvest a data.json https://data.edd.ca.gov/data.json
  The custom schema has required fields and will need the following JSON in the config text box.
```
{
  "contact_point":{  
    "name_field":"contact_name",
    "email_field":"contact_email",
    "default_name":"noemailprovided",
    "default_email":"noemailprovided@usa.gov"
  },
  "default_values":[  
    {  
      "accrualPeriodicity":"irregular"
    }
  ]
}
```