### PR TITLE
[PA-841] Trigger xloader on harvest update

### DIFF
--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -11,6 +11,11 @@ from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
 from ckanext.dcat import converters
 from ckanext.dcat.harvesters.base import DCATHarvester
 
+try:
+    from ckan.common import config
+except ImportError:
+    from pylons import config
+
 log = logging.getLogger(__name__)
 
 
@@ -306,7 +311,7 @@ class DCATJSONHarvester(DCATHarvester):
                 p.toolkit.get_action('package_update')(context, package_dict)
             log.info('Updated dataset with id %s', package_id)
 
-            # Xloader isn't triggered since resource urls do not change
+            # Xloader isn't triggered since resource urls may not change
             context = {'model': model, 'session': model.Session,
                        'user': self._get_user_name()}
             updated_dataset = p.toolkit.get_action('package_show')(context, {'id': package_id})


### PR DESCRIPTION
## [TICKET](https://opengovinc.atlassian.net/browse/PA-841)

## Description
<!--- Describe these changes in detail --->
This PR updates the datajson harvester to trigger the xloader on harvest updates. The xloader isn't always triggered since resource urls do not change most of the time.

The code is coming from the ckanext-opengov extension.
https://github.com/OpenGov/ckanext-opengov/blob/master/ckanext/opengov/harvesters/opengov.py#L621-L637

**Test Instructions:**
1. Run a harvest manually that has a dataset that has at least one CSV resource
2. Confirm that on the first harvest it has been pushed to the datastore
3. Confirm the Data API buttons are visible
4. Trigger reharvest manually, confirm the resource has been repushed to the datastore via xloader (Confirm this by checking the datastore tab timing / Logs for xloader)
5. Confirm the Data API button and data table preview is still available