### PR TITLE
Handle import stage errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In terms of CKAN features, this extension offers:
 
 * An [RDF Harvester](#rdf-dcat-harvester) that allows importing RDF serializations from other catalogs to create CKAN datasets (`dcat_rdf_harvester` plugin).
 
-* An [JSON DCAT Harvester](#json-dcat-harvester) that allows importing JSON objects that are based on DCAT terms but are not defined as JSON-LD, using the serialization described in the [spec.datacatalogs.org](http://spec.datacatalogs.org/#datasets_serialization_format) site (`dcat_json_harvester` plugin)..
+* An [JSON DCAT Harvester](#json-dcat-harvester) that allows importing JSON objects that are based on DCAT terms but are not defined as JSON-LD, using the serialization described in the [spec.dataportals.org](http://spec.dataportals.org/#datasets-serialization-format) site (`dcat_json_harvester` plugin)..
 
 
 These are implemented internally using:
@@ -281,7 +281,7 @@ To know more about these methods, please check the source of [`ckanext-dcat/ckan
 ## JSON DCAT harvester
 
 The DCAT JSON harvester supports importing JSON objects that are based on DCAT terms but are not defined as JSON-LD. The exact format for these JSON files
-is the one described in the [spec.datacatalogs.org](http://spec.datacatalogs.org/#datasets_serialization_format) site. There are [example files](https://github.com/ckan/ckanext-dcat/blob/master/examples/dataset.json) in the `examples` folder.
+is the one described in the [spec.dataportals.org](http://spec.dataportals.org/#datasets-serialization-format) site. There are [example files](https://github.com/ckan/ckanext-dcat/blob/master/examples/dataset.json) in the `examples` folder.
 
 To enable the JSON harvester, add the `dcat_json_harvester` plugin to your CKAN configuration file:
 

--- a/ckanext/dcat/controllers.py
+++ b/ckanext/dcat/controllers.py
@@ -18,6 +18,7 @@ else:
     from ckan.views.dataset import read as read_endpoint
 
 from ckanext.dcat.utils import CONTENT_TYPES, parse_accept_header
+from ckanext.dcat.processors import RDFProfileException
 
 
 def _get_package_type(id):
@@ -66,7 +67,7 @@ class DCATController(BaseController):
             {'Content-type': CONTENT_TYPES[_format]})
         try:
             return toolkit.get_action('dcat_catalog_show')({}, data_dict)
-        except toolkit.ValidationError, e:
+        except (toolkit.ValidationError, RDFProfileException) as e:
             toolkit.abort(409, str(e))
 
     def read_dataset(self, _id, _format=None):
@@ -92,6 +93,8 @@ class DCATController(BaseController):
                 'format': _format, 'profiles': _profiles})
         except toolkit.ObjectNotFound:
             toolkit.abort(404)
+        except (toolkit.ValidationError, RDFProfileException) as e:
+            toolkit.abort(409, str(e))
 
         return result
 

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -252,39 +252,39 @@ class DCATJSONHarvester(DCATHarvester):
             'ignore_auth': True,
         }
 
-        try:
-            if status == 'new':
+        if status == 'new':
 
-                package_schema = logic.schema.default_create_package_schema()
-                context['schema'] = package_schema
+            package_schema = logic.schema.default_create_package_schema()
+            context['schema'] = package_schema
 
-                # We need to explicitly provide a package ID
-                package_dict['id'] = unicode(uuid.uuid4())
-                package_schema['id'] = [unicode]
+            # We need to explicitly provide a package ID
+            package_dict['id'] = unicode(uuid.uuid4())
+            package_schema['id'] = [unicode]
 
-                # Save reference to the package on the object
-                harvest_object.package_id = package_dict['id']
-                harvest_object.add()
+            # Save reference to the package on the object
+            harvest_object.package_id = package_dict['id']
+            harvest_object.add()
 
-                # Defer constraints and flush so the dataset can be indexed with
-                # the harvest object id (on the after_show hook from the harvester
-                # plugin)
-                model.Session.execute(
-                    'SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
-                model.Session.flush()
+            # Defer constraints and flush so the dataset can be indexed with
+            # the harvest object id (on the after_show hook from the harvester
+            # plugin)
+            model.Session.execute(
+                'SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
+            model.Session.flush()
 
-                package_id = \
-                    p.toolkit.get_action('package_create')(context, package_dict)
-                log.info('Created dataset with id %s', package_id)
+        elif status == 'change':
+            package_dict['id'] = harvest_object.package_id
 
-            elif status == 'change':
-                package_dict['id'] = harvest_object.package_id
-                package_id = \
-                    p.toolkit.get_action('package_update')(context, package_dict)
-                log.info('Updated dataset with id %s', package_id)
-        except p.toolkit.ValidationError, e:
-            self._save_object_error('Validation Error: %s' % str(e), harvest_object, 'Import')
-            return False
+        if status in ['new', 'change']:
+            try:
+                action = 'package_create' if status == 'new' else 'package_update'
+                message_status = 'Created' if status == 'new' else 'Updated'
+
+                package_id = p.toolkit.get_action(action)(context, package_dict)
+                log.info('%s dataset with id %s', message_status, package_id)
+            except p.toolkit.ValidationError, e:
+                self._save_object_error('Validation Error: %s' % str(e), harvest_object, 'Import')
+                return False
 
         model.Session.commit()
 

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from hashlib import sha1
+import traceback
 import uuid
 
 from ckan import model
@@ -252,41 +253,45 @@ class DCATJSONHarvester(DCATHarvester):
             'ignore_auth': True,
         }
 
-        if status == 'new':
+        try:
+            if status == 'new':
+                package_schema = logic.schema.default_create_package_schema()
+                context['schema'] = package_schema
 
-            package_schema = logic.schema.default_create_package_schema()
-            context['schema'] = package_schema
+                # We need to explicitly provide a package ID
+                package_dict['id'] = unicode(uuid.uuid4())
+                package_schema['id'] = [unicode]
 
-            # We need to explicitly provide a package ID
-            package_dict['id'] = unicode(uuid.uuid4())
-            package_schema['id'] = [unicode]
+                # Save reference to the package on the object
+                harvest_object.package_id = package_dict['id']
+                harvest_object.add()
 
-            # Save reference to the package on the object
-            harvest_object.package_id = package_dict['id']
-            harvest_object.add()
+                # Defer constraints and flush so the dataset can be indexed with
+                # the harvest object id (on the after_show hook from the harvester
+                # plugin)
+                model.Session.execute(
+                    'SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
+                model.Session.flush()
 
-            # Defer constraints and flush so the dataset can be indexed with
-            # the harvest object id (on the after_show hook from the harvester
-            # plugin)
-            model.Session.execute(
-                'SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED')
-            model.Session.flush()
+            elif status == 'change':
+                package_dict['id'] = harvest_object.package_id
 
-        elif status == 'change':
-            package_dict['id'] = harvest_object.package_id
-
-        if status in ['new', 'change']:
-            try:
+            if status in ['new', 'change']:
                 action = 'package_create' if status == 'new' else 'package_update'
                 message_status = 'Created' if status == 'new' else 'Updated'
 
                 package_id = p.toolkit.get_action(action)(context, package_dict)
                 log.info('%s dataset with id %s', message_status, package_id)
-            except p.toolkit.ValidationError, e:
-                self._save_object_error('Validation Error: %s' % str(e), harvest_object, 'Import')
-                return False
 
-        model.Session.commit()
+        except Exception, e:
+            dataset = json.loads(harvest_object.content)
+            dataset_name = dataset.get('name', '')
+
+            self._save_object_error('Error importing dataset %s: %r / %s' % (dataset_name, e, traceback.format_exc()), harvest_object, 'Import')
+            return False
+
+        finally:
+            model.Session.commit()
 
         return True
 

--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -151,7 +151,7 @@ def _pagination_info(query, data_dict):
             base_url, toolkit.request.path)
 
         params = [p for p in toolkit.request.params.iteritems()
-                  if p[0] != 'page']
+                  if p[0] != 'page' and p[0] in ('modified_since', 'profiles')]
         if params:
             qs = '&'.join(['{0}={1}'.format(p[0], p[1]) for p in params])
             return '{0}?{1}&page={2}'.format(

--- a/ckanext/dcat/tests/test_controllers.py
+++ b/ckanext/dcat/tests/test_controllers.py
@@ -205,6 +205,20 @@ class TestEndpoints(DCATFunctionalTestBase):
         assert '"@type": "schema:Dataset"' in content
         assert '"schema:description": "%s"' % dataset['notes'] in content
 
+    def test_dataset_profiles_not_found(self):
+
+        dataset = factories.Dataset(
+            notes='Test dataset'
+        )
+
+        url = url_for('dcat_dataset', _id=dataset['name'], _format='jsonld', profiles='nope')
+
+        app = self._get_test_app()
+
+        response = app.get(url, status=409)
+
+        assert 'Unknown RDF profiles: nope' in response.body
+
     def test_dataset_not_found(self):
         import uuid
 
@@ -354,6 +368,42 @@ class TestEndpoints(DCATFunctionalTestBase):
 
         eq_(self._object_value(g, pagination, HYDRA.lastPage),
             url_for('dcat_catalog', _format='rdf', page=2, host='test.ckan.net'))
+
+    @helpers.change_config('ckanext.dcat.datasets_per_page', 10)
+    def test_catalog_pagination_parameters(self):
+
+        for i in xrange(12):
+            factories.Dataset()
+
+        app = self._get_test_app()
+
+        url = url_for('dcat_catalog', _format='rdf', modified_since='2018-03-22', extra_param='test')
+
+        response = app.get(url)
+
+        content = response.body
+
+        g = Graph()
+        g.parse(data=content, format='xml')
+
+
+        pagination = [o for o in g.subjects(RDF.type, HYDRA.PagedCollection)][0]
+
+        eq_(self._object_value(g, pagination, HYDRA.itemsPerPage), '10')
+
+        eq_(self._object_value(g, pagination, HYDRA.firstPage),
+            url_for('dcat_catalog', _format='rdf', page=1, host='test.ckan.net', modified_since='2018-03-22'))
+
+    def test_catalog_profiles_not_found(self):
+
+        url = url_for('dcat_catalog', _format='jsonld', profiles='nope')
+
+        app = self._get_test_app()
+
+        response = app.get(url, status=409)
+
+        assert 'Unknown RDF profiles: nope' in response.body
+
 
     @helpers.change_config('ckanext.dcat.enable_rdf_endpoints', False)
     def test_catalog_endpoint_disabled(self):

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -323,26 +323,3 @@ class TestImportStage:
 
         assert 'Error importing dataset Invalid tags: ValidationError(None,)' in args[0]
         assert '{\'tags\': [{}, u\'Tag "test\\\'s" must be alphanumeric characters or symbols: -_.\', u\'Tag "invalid & wrong" must be alphanumeric characters or symbols: -_.\']}' in args[0]
-
-    @patch('ckanext.dcat.harvesters._json.model.Package.get')
-    @patch('ckanext.dcat.harvesters._json.DCATJSONHarvester._save_object_error')
-    @patch('ckan.logic.schema.default_create_package_schema')
-    def test_import_invalid_tags_raise_generic_exception(
-        self, mock_default_create_package_schema, mock_save_object_error, mock_model_package_get
-    ):
-        mock_default_create_package_schema.side_effect = Exception('Internal Server Error')
-        user = factories.User()
-        owner_org = factories.Organization(
-            users=[{'name': user['id'], 'capacity': 'admin'}]
-        )
-
-        mock_model_package_get.return_value = self.MockSourceDataset(owner_org)
-
-        harvester = DCATJSONHarvester()
-
-        mock_harvest_object = self.MockHarvestObject()
-        harvester.import_stage(mock_harvest_object)
-
-        args, _ = mock_save_object_error.call_args_list[0]
-
-        assert "Error importing dataset Invalid tags: Exception('Internal Server Error',)" in args[0]

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -1,5 +1,5 @@
 import httpretty
-from mock import patch
+from mock import call, patch
 
 import nose
 
@@ -318,8 +318,7 @@ class TestImportStage:
         mock_harvest_object = self.MockHarvestObject()
         harvester.import_stage(mock_harvest_object)
 
-        mock_save_object_error.assert_called_once_with(
-            'Validation Error: {\'tags\': [{}, u\'Tag "test\\\'s" must be alphanumeric characters or symbols: -_.\', u\'Tag "invalid & wrong" must be alphanumeric characters or symbols: -_.\']}',
-            mock_harvest_object,
-            'Import'
-        )
+        args, _ = mock_save_object_error.call_args_list[0]
+
+        assert 'Validation Error:' in args[0]
+        assert '{\'tags\': [{}, u\'Tag "test\\\'s" must be alphanumeric characters or symbols: -_.\', u\'Tag "invalid & wrong" must be alphanumeric characters or symbols: -_.\']}' in args[0]

--- a/ckanext/dcat/tests/test_json_harvester.py
+++ b/ckanext/dcat/tests/test_json_harvester.py
@@ -1,14 +1,32 @@
 import httpretty
+from mock import patch
+
 import nose
 
+from ckan.logic import ValidationError
 import ckantoolkit.tests.helpers as h
 
-from ckanext.dcat.harvesters._json import copy_across_resource_ids
+import ckan.tests.factories as factories
+
+from ckanext.dcat.harvesters._json import copy_across_resource_ids, DCATJSONHarvester
 from test_harvester import FunctionalHarvestTest
 
 eq_ = nose.tools.eq_
 
 class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
+
+    # invalid tags dataset
+    json_content_invalid_tags = '''
+        {
+        "@type": "dcat:Dataset",
+        "identifier": "http://example.com/datasets/invalid_example",
+        "title": "Example dataset with invalid tags",
+        "description": "Invalid keywords",
+        "publisher": {"name":"Example Department of Wildlife"},
+        "license": "https://example.com/license",
+        "keyword": ["example", "test's", "invalid & wrong"]
+        }
+    '''
 
     @classmethod
     def setup_class(cls):
@@ -61,14 +79,21 @@ class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
 }
         '''
 
+        # invalid_tags dataset
+        cls.json_content_invalid_tags_dataset = '{"dataset":[%s]}' % cls.json_content_invalid_tags
+
     def test_harvest_create(self):
 
         self._test_harvest_create(self.json_mock_url,
                                   self.json_content,
-                                  self.json_content_type)
+                                  self.json_content_type,
+                                  exp_titles=['Example dataset 1', 'Example dataset 2'])
 
-    def _test_harvest_create(self, url, content, content_type, num_datasets=2,
-                             **kwargs):
+    def _test_harvest_create(
+        self, url, content, content_type, num_datasets=2,
+        exp_num_datasets=2, exp_titles=[],
+        **kwargs
+    ):
 
         # Mock the GET request to get the file
         httpretty.register_uri(httpretty.GET, url,
@@ -87,16 +112,15 @@ class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
         fq = "+type:dataset harvest_source_id:{0}".format(harvest_source['id'])
         results = h.call_action('package_search', {}, fq=fq)
 
-        eq_(results['count'], num_datasets)
-        for result in results['results']:
-            assert result['title'] in ('Example dataset 1',
-                                       'Example dataset 2')
+        eq_(results['count'], exp_num_datasets)
+
+        if exp_titles:
+            for result in results['results']:
+                assert result['title'] in exp_titles
 
     def test_harvest_update_existing_resources(self):
 
         content = self.json_content_with_distribution
-        # content_modified = content.replace('Example dataset 1',
-        #                                    'Example dataset 1 (updated)')
         existing_resources, new_resources = \
             self._test_harvest_twice(content, content)
 
@@ -178,6 +202,14 @@ class TestDCATJSONHarvestFunctional(FunctionalHarvestTest):
 
         return (existing_resources, new_resources)
 
+    def test_harvest_does_not_create_with_invalid_tags(self):
+        self._test_harvest_create(
+            'http://some.dcat.file.invalid.json',
+            self.json_content_invalid_tags_dataset,
+            self.json_content_type,
+            num_datasets=1,
+            exp_num_datasets=0)
+
 
 class TestCopyAcrossResourceIds:
     def test_copied_because_same_uri(self):
@@ -238,3 +270,56 @@ class TestCopyAcrossResourceIds:
             harvested_dataset,
         )
         eq_(harvested_dataset['resources'][0].get('id'), None)
+
+
+class TestImportStage:
+
+    @classmethod
+    def setup_class(cls):
+        h.reset_db()
+
+    class MockHarvestObject:
+        guid = 'test_guid'
+        content = TestDCATJSONHarvestFunctional.json_content_invalid_tags
+
+        class MockStatus:
+            key = 'status'
+            value = 'new'
+
+        extras = [MockStatus()]
+        package = None
+
+        class MockSource:
+            id = 'test_id'
+
+        source = MockSource()
+
+        def add(self):
+            pass
+
+    class MockSourceDataset:
+        def __init__(self, owner_org=None):
+            self.owner_org = owner_org['id']
+
+    @patch('ckanext.dcat.harvesters._json.model.Package.get')
+    @patch('ckanext.dcat.harvesters._json.DCATJSONHarvester._save_object_error')
+    def test_import_invalid_tags(
+        self, mock_save_object_error, mock_model_package_get
+    ):
+        user = factories.User()
+        owner_org = factories.Organization(
+            users=[{'name': user['id'], 'capacity': 'admin'}]
+        )
+
+        mock_model_package_get.return_value = self.MockSourceDataset(owner_org)
+
+        harvester = DCATJSONHarvester()
+
+        mock_harvest_object = self.MockHarvestObject()
+        harvester.import_stage(mock_harvest_object)
+
+        mock_save_object_error.assert_called_once_with(
+            'Validation Error: {\'tags\': [{}, u\'Tag "test\\\'s" must be alphanumeric characters or symbols: -_.\', u\'Tag "invalid & wrong" must be alphanumeric characters or symbols: -_.\']}',
+            mock_harvest_object,
+            'Import'
+        )

--- a/ckanext/dcat/tests/test_logic.py
+++ b/ckanext/dcat/tests/test_logic.py
@@ -170,9 +170,9 @@ class TestPagination(object):
     @helpers.change_config('ckanext.dcat.datasets_per_page', 10)
     @helpers.change_config('ckan.site_url', 'http://example.com')
     @mock.patch('ckan.plugins.toolkit.request')
-    def test_pagination_keeps_params(self, mock_request):
+    def test_pagination_keeps_only_supported_params(self, mock_request):
 
-        mock_request.params = {'a': 1, 'b': 2}
+        mock_request.params = {'a': 1, 'b': 2, 'modified_since': '2018-03-22', 'profiles': 'schemaorg'}
         mock_request.host_url = 'http://ckan.example.com'
         mock_request.path = '/feed/catalog.xml'
 
@@ -190,10 +190,10 @@ class TestPagination(object):
         eq_(pagination['count'], 12)
         eq_(pagination['items_per_page'],
             config.get('ckanext.dcat.datasets_per_page'))
-        eq_(pagination['current'], 'http://example.com/feed/catalog.xml?a=1&b=2&page=1')
-        eq_(pagination['first'], 'http://example.com/feed/catalog.xml?a=1&b=2&page=1')
-        eq_(pagination['last'], 'http://example.com/feed/catalog.xml?a=1&b=2&page=2')
-        eq_(pagination['next'], 'http://example.com/feed/catalog.xml?a=1&b=2&page=2')
+        eq_(pagination['current'], 'http://example.com/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1')
+        eq_(pagination['first'], 'http://example.com/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=1')
+        eq_(pagination['last'], 'http://example.com/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2')
+        eq_(pagination['next'], 'http://example.com/feed/catalog.xml?modified_since=2018-03-22&profiles=schemaorg&page=2')
         assert 'previous' not in pagination
 
     @helpers.change_config('ckanext.dcat.datasets_per_page', 10)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.3.2
 httpretty==0.6.2
+mock==2.0.0


### PR DESCRIPTION
## Description
Our fetch process often stops because of Validation Errors which were not properly handled in the import_stage. This would eventually lead to the process dying after a number of retries.

This PR merges commits from upstream to fix the fetch errors with try catch statements.