### PR TITLE
[PA-923] Remove trigger for xloader to revert to past behavior

### DIFF
--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import logging
+import re
 
 import requests
 import rdflib
@@ -11,33 +12,31 @@ from ckan import model
 
 from ckan.logic import ValidationError, NotFound, get_action
 from ckan.lib.helpers import json
+from ckan.lib.munge import substitute_ascii_equivalents
 
 from ckanext.harvest.harvesters import HarvesterBase
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
 
 from ckanext.dcat.interfaces import IDCATRDFHarvester
 
-if p.toolkit.check_ckan_version(min_version='2.3'):
-    from ckan.lib.munge import munge_tag
-else:
-    # Fallback munge_tag for older ckan versions which don't have a decent
-    # munger
-    def _munge_to_length(string, min_length, max_length):
-        '''Pad/truncates a string'''
-        if len(string) < min_length:
-            string += '_' * (min_length - len(string))
-        if len(string) > max_length:
-            string = string[:max_length]
-        return string
-
-    def munge_tag(tag):
-        tag = substitute_ascii_equivalents(tag)
-        tag = tag.lower().strip()
-        tag = re.sub(r'[^a-zA-Z0-9\- ]', '', tag).replace(' ', '-')
-        tag = _munge_to_length(tag, model.MIN_TAG_LENGTH, model.MAX_TAG_LENGTH)
-        return tag
 
 log = logging.getLogger(__name__)
+
+
+def _munge_to_length(string, min_length, max_length):
+    '''Pad/truncates a string'''
+    if len(string) < min_length:
+        string += '_' * (min_length - len(string))
+    if len(string) > max_length:
+        string = string[:max_length]
+    return string
+
+def munge_tag(tag):
+    tag = substitute_ascii_equivalents(tag)
+    tag = tag.lower().strip()
+    tag = re.sub(r'[^a-zA-Z0-9\- ]', '', tag)
+    tag = _munge_to_length(tag, model.MIN_TAG_LENGTH, model.MAX_TAG_LENGTH)
+    return tag
 
 
 class DCATHarvester(HarvesterBase):


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [PA-923](https://opengovinc.atlassian.net/browse/PA-923)

## Description
<!--- Describe these changes in detail --->
This PR updates the datajson harvester with the following changes:
- **Remove trigger for xloader to revert to past behavior**
Remove the changes that was added in https://github.com/OpenGov-OpenData/ckanext-dcat/commit/509550e5560db1b72c90f3009057b45aed9550ae. Now xloader will run only when resource url changes.
- **Copy over existing resource metadata about the datastore when datasets are reharvested**
The xloader extension adds the 2 fields `datastore_active` and `datastore_contains_all_records_of_source_file` to the resource metadata, which should be preserved. There was a previous issue where the Data API button disappears when the datastore metadata is not copied over.
https://github.com/ckan/ckanext-xloader/blob/0.4.1/ckanext/xloader/jobs.py#L373-L375
- **Allow spaces in tags**
When munging the tags of harvested datasets the space character should be allowed.

## Testing
- Install the ckanext-harvest extension
- Enable datastore, xloader, harvest and dcat_json_harvester in the CKAN ini file
- Harvest a datajson endpoint like California Franchise Tax Board (https://data.ftb.ca.gov/data.json)
  - During the initial run of the harvest job logs should indicate that the xloader service is running.
  - When the harvest job is ran again the logs should not show xloader being triggered.
- Tags should have space characters and the Data API button should appear for tabular resources.