### PR TITLE
[ESN-870] fix delete dataset logic

### DIFF
--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -194,11 +194,8 @@ class DCATJSONHarvester(DCATHarvester):
                 guid=guid, job=harvest_job,
                 package_id=guid_to_package_id[guid],
                 extras=[HarvestObjectExtra(key='status', value='delete')])
-            ids.append(obj.id)
-            model.Session.query(HarvestObject).\
-                filter_by(guid=guid).\
-                update({'current': False}, False)
             obj.save()
+            ids.append(obj.id)
 
         return ids
 
@@ -225,6 +222,11 @@ class DCATJSONHarvester(DCATHarvester):
                 context, {'id': harvest_object.package_id})
             log.info('Deleted package {0} with guid {1}'
                      .format(harvest_object.package_id, harvest_object.guid))
+
+            model.Session.query(HarvestObject).\
+                filter_by(guid=harvest_object.guid).\
+                filter_by(current=True).\
+                update({'current': False}, False)
 
             return True
 

--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -303,7 +303,7 @@ class DCATHarvester(HarvesterBase):
                 package_dict['extras'].remove(existing_extra)
 
         if email_field:
-            contactPointEmail = contactPoint.get('hasEmail', ':').split(':')[1] or \
+            contactPointEmail = contactPoint.get('hasEmail', ':').split(':')[-1] or \
                                 contact_point_mapping.get('default_email')
             package_dict[email_field] = contactPointEmail
             # Remove from extras the email field


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [ESN-870](https://opengovinc.atlassian.net/browse/ESN-870)

## Description
<!--- Describe these changes in detail --->
This PR updates the datajson harvester to fix the logic where datasets that were removed from the harvest data.json source were not deleted from CKAN.

The issue was that during the import stage the harvest object ID of a deleted dataset was not correctly set. This is because the harvest object ID is appended to an array before the harvest object is generated in obj.save().
```
# Check datasets that need to be deleted
guids_to_delete = set(guids_in_db) - set(guids_in_source)
for guid in guids_to_delete:
    obj = HarvestObject(
        guid=guid, job=harvest_job,
        package_id=guid_to_package_id[guid],
        extras=[HarvestObjectExtra(key='status', value='delete')])
    ids.append(obj.id)    # This line should occur after the object is generated
    model.Session.query(HarvestObject).\
        filter_by(guid=guid).\
        update({'current': False}, False)
    obj.save()
```

To fix the this the append occurs after `obj.save()` and the harvest object's `current` state is set to false only when the dataset is actually deleted.

## Testing
- Install the ckanext-harvest extension
- Enable datastore, xloader, harvest and dcat_json_harvester in the CKAN ini file
- Restart supervisor service
```
sudo service supervisor restart
```
- Harvest an organization datajson endpoint from CKAN sandbox (For example: https://ckansandbox.ogopendata.com/organization/california-health-and-human-services-agency-chhs/data.json)
- After the harvest job is done delete a dataset from the test organization and check that the data.json endpoint is updated with the change.
- Run the harvest job and check that the dataset is deleted after the harvest job is done.