### PR TITLE
[PERF-493] Add file format whitelist/blacklist

### DIFF
--- a/ckanext/dcat/converters.py
+++ b/ckanext/dcat/converters.py
@@ -2,6 +2,11 @@ import logging
 import mimetypes
 import re
 
+try:
+    from ckan.common import config
+except ImportError:
+    from pylons import config
+
 log = logging.getLogger(__name__)
 mimetypes.init()
 
@@ -58,6 +63,15 @@ def dcat_to_ckan(dcat_dict):
             ext = mimetypes.guess_extension(distribution.get('mediaType'))
             if ext:
                 format = ext[1:]
+
+        # skip disallowed formats
+        clean_format = ''.join(format.split()).lower()
+        if disallow_file_format(clean_format):
+            log.debug('Skip disallowed format %s: %s' % (
+                format, distribution.get('downloadURL') or distribution.get('accessURL'))
+            )
+            continue
+
         resource = {
             'name': distribution.get('title', dcat_dict.get('title')),
             'description': distribution.get('description'),
@@ -125,3 +139,36 @@ def ckan_to_dcat(package_dict):
         dcat_dict['distribution'].append(distribution)
 
     return dcat_dict
+
+
+def disallow_file_format(file_format):
+    if config.get('ckanext.format_filter.filter_type') == 'whitelist':
+        if file_format in get_whitelist():
+            return False
+        return True
+    elif config.get('ckanext.format_filter.filter_type') == 'blacklist':
+        if file_format in get_blacklist():
+            return True
+    return False
+
+
+def get_whitelist():
+    whitelist_string = config.get('ckanext.format_filter.whitelist', '')
+    return convert_to_filter_list(whitelist_string)
+
+
+def get_blacklist():
+    blacklist_string = config.get('ckanext.format_filter.blacklist', '')
+    return convert_to_filter_list(blacklist_string)
+
+
+def convert_to_filter_list(filter_string):
+    format_list = []
+    try:
+        if filter_string:
+            if isinstance(filter_string, str):
+                filter_string = filter_string.split()
+                format_list = [file_format.lower() for file_format in filter_string]
+    except Exception as e:
+        log.error(e)
+    return format_list

--- a/ckanext/dcat/tests/test_format_filter.py
+++ b/ckanext/dcat/tests/test_format_filter.py
@@ -1,0 +1,38 @@
+import nose
+from ckantoolkit.tests import helpers
+
+from ckanext.dcat import converters
+
+eq_ = nose.tools.eq_
+
+
+class TestFormatFilters(object):
+    @helpers.change_config('ckanext.file_filter.filter_type', 'whitelist')
+    @helpers.change_config('ckanext.file_filter.whitelist', 'csv xlsx pdf')
+
+    def test_get_whitelist(self):
+        whitelist = converters.get_whitelist()
+        eq_(len(whitelist), 3)
+        assert 'csv' in whitelist
+        assert 'xlsx' in whitelist
+
+    def test_whitelist_filter(self):
+        disallow_exe = converters.disallow_file_format('exe')
+        eq_(disallow_exe, True)
+
+        disallow_csv = converters.disallow_file_format('csv')
+        eq_(disallow_csv, False)
+
+    @helpers.change_config('ckanext.file_filter.filter_type', 'blacklist')
+    @helpers.change_config('ckanext.file_filter.blacklist', 'exe jar')
+    def test_get_blacklist(self):
+        blacklist = converters.get_blacklist()
+        eq_(len(blacklist), 2)
+        assert 'exe' in blacklist
+
+    def test_blacklist_filter(self):
+        disallow_exe = converters.disallow_file_format('exe')
+        eq_(disallow_exe, True)
+
+        disallow_csv = converters.disallow_file_format('csv')
+        eq_(disallow_csv, False)

--- a/ckanext/dcat/tests/test_format_filter.py
+++ b/ckanext/dcat/tests/test_format_filter.py
@@ -9,7 +9,6 @@ eq_ = nose.tools.eq_
 class TestFormatFilters(object):
     @helpers.change_config('ckanext.file_filter.filter_type', 'whitelist')
     @helpers.change_config('ckanext.file_filter.whitelist', 'csv xlsx pdf')
-
     def test_get_whitelist(self):
         whitelist = converters.get_whitelist()
         eq_(len(whitelist), 3)

--- a/test.ini
+++ b/test.ini
@@ -22,6 +22,10 @@ ckan.activity_streams_enabled = false
 
 ckan.harvest.mq.type = redis
 
+ckanext.format_filter.filter_type = whitelist
+ckanext.format_filter.whitelist = csv xlsx pdf
+ckanext.format_filter.blacklist = exe jar
+
 # Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [PERF-493](https://opengovinc.atlassian.net/browse/PERF-493)

## Description
<!--- Describe these changes in detail --->
This PR adds a whitelist/blacklist feature to the datajson harvester. The json harvester will skip resources that are disallowed by the whitelist/blacklist. Either a whitelist or blacklist can be configured, but both can not be enabled at the same time.

## Testing
- Install the ckanext-harvest extension if it wasn't done before
```
. /usr/lib/ckan/default/bin/activate
cd /usr/lib/ckan/default/src
git clone https://github.com/OpenGov-OpenData/ckanext-harvest
cd ckanext-harvest
git checkout v1.2.1-opengov
python setup.py develop
paster harvester initdb -c /etc/ckan/default/development.ini
```
- Install the dcat extension and checkout this PR's branch
```
cd /usr/lib/ckan/default/src
git clone https://github.com/OpenGov-OpenData/ckanext-dcat
cd ckanext-dcat
git checkout jguo144/PEF-493/2020-03-04/add-file-type-whitelist-blacklist
python setup.py develop
```
- Enable harvest and dcat_json_harvester plugins in the CKAN ini file
```
ckan.plugins = ... harvest dcat_json_harvester ...
```
- Add format filter configuration to the CKAN ini file
```
ckanext.format_filter.filter_type = whitelist
ckanext.format_filter.whitelist = csv xlsx pdf esrirest
```
- Restart supervisor service and wait a few seconds while the gather/fetch queue restart
```
sudo service supervisor restart
sudo supervisorctl status
```
- Start CKAN
```
cd /usr/lib/ckan/default/src/ckan
paster serve /etc/ckan/default/development.ini
``` 
- Harvest a data.json file with multiple types of formats (i.e. https://data-cdtfa.opendata.arcgis.com/data.json has the formats html, csv, geojson, kml, and esri rest)
- Run the harvest job and confirm that only formats define in the whitelist are added to CKAN