### PR TITLE
[PERF-962] check timestamp

### DIFF
--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -188,11 +188,11 @@ class DCATHarvester(HarvesterBase):
         '''
 
         datasets = model.Session.query(model.Package.id) \
-            .join(model.PackageExtra) \
-            .filter(model.PackageExtra.key == 'guid') \
-            .filter(model.PackageExtra.value == guid) \
-            .filter(model.Package.state == 'active') \
-            .all()
+                                .join(model.PackageExtra) \
+                                .filter(model.PackageExtra.key == 'guid') \
+                                .filter(model.PackageExtra.value == guid) \
+                                .filter(model.Package.state == 'active') \
+                                .all()
 
         if not datasets:
             return None

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -1,7 +1,5 @@
 from ckan import plugins as p
 from pylons import config
-import dateutil
-import re
 
 from ckanext.dcat.utils import parse_date_iso_format
 

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -1,5 +1,6 @@
 from ckan import plugins as p
 from pylons import config
+import dateutil
 
 try:
     from ckan.lib.plugins import DefaultTranslation
@@ -128,12 +129,21 @@ class DCATPlugin(p.SingletonPlugin, DefaultTranslation):
         return data_dict
 
     def before_index(self, pkg_dict):
+
         dcat_modified = pkg_dict.get('extras_dcat_modified')
         dcat_issued = pkg_dict.get('extras_dcat_issued')
-        if dcat_modified:
-            pkg_dict['metadata_modified'] = dcat_modified
-        if dcat_modified:
-            pkg_dict['metadata_created'] = dcat_issued
+        try:
+            if dcat_modified:
+                dateutil.parser.parse(dcat_modified)
+            if dcat_issued:
+                dateutil.parser.parse(dcat_issued)
+        except ValueError:
+            return pkg_dict
+        else:
+            if dcat_modified:
+                pkg_dict['metadata_modified'] = dcat_modified
+            if dcat_modified:
+                pkg_dict['metadata_created'] = dcat_issued
 
         return pkg_dict
 

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -1,6 +1,9 @@
 from ckan import plugins as p
 from pylons import config
 import dateutil
+import re
+
+from ckanext.dcat.utils import check_if_date_is_iso_format
 
 try:
     from ckan.lib.plugins import DefaultTranslation
@@ -129,21 +132,13 @@ class DCATPlugin(p.SingletonPlugin, DefaultTranslation):
         return data_dict
 
     def before_index(self, pkg_dict):
-
         dcat_modified = pkg_dict.get('extras_dcat_modified')
         dcat_issued = pkg_dict.get('extras_dcat_issued')
-        try:
-            if dcat_modified:
-                dateutil.parser.parse(dcat_modified)
-            if dcat_issued:
-                dateutil.parser.parse(dcat_issued)
-        except ValueError:
-            return pkg_dict
-        else:
-            if dcat_modified:
-                pkg_dict['metadata_modified'] = dcat_modified
-            if dcat_modified:
-                pkg_dict['metadata_created'] = dcat_issued
+
+        if dcat_modified and check_if_date_is_iso_format(dcat_modified):
+            pkg_dict['metadata_modified'] = dcat_modified
+        if dcat_modified and check_if_date_is_iso_format(dcat_modified):
+            pkg_dict['metadata_created'] = dcat_issued
 
         return pkg_dict
 

--- a/ckanext/dcat/plugins.py
+++ b/ckanext/dcat/plugins.py
@@ -3,7 +3,7 @@ from pylons import config
 import dateutil
 import re
 
-from ckanext.dcat.utils import check_if_date_is_iso_format
+from ckanext.dcat.utils import parse_date_iso_format
 
 try:
     from ckan.lib.plugins import DefaultTranslation
@@ -132,12 +132,12 @@ class DCATPlugin(p.SingletonPlugin, DefaultTranslation):
         return data_dict
 
     def before_index(self, pkg_dict):
-        dcat_modified = pkg_dict.get('extras_dcat_modified')
-        dcat_issued = pkg_dict.get('extras_dcat_issued')
-
-        if dcat_modified and check_if_date_is_iso_format(dcat_modified):
+        dcat_modified = parse_date_iso_format(pkg_dict.get('extras_dcat_modified'))
+        if dcat_modified:
             pkg_dict['metadata_modified'] = dcat_modified
-        if dcat_modified and check_if_date_is_iso_format(dcat_modified):
+
+        dcat_issued = parse_date_iso_format(pkg_dict.get('extras_dcat_issued'))
+        if dcat_issued:
             pkg_dict['metadata_created'] = dcat_issued
 
         return pkg_dict

--- a/ckanext/dcat/tests/test_utils.py
+++ b/ckanext/dcat/tests/test_utils.py
@@ -136,12 +136,27 @@ class TestDateIsoFormat(object):
         _date = parse_date_iso_format(date)
         eq_(_date, None)
 
-    def test_date(self):
-        date = '2020-07-07'
+    def test_date_command(self):
+        date = 'Thu Sep 25 10:36:28 2020'
         _date = parse_date_iso_format(date)
-        eq_(_date, '2020-07-07T00:00:00')
+        eq_(_date, '2020-09-25T10:36:28')
 
-    def test_datetime(self):
-        date = '2020-07-07T20:15:59.642761'
+    def test_iso_datetime(self):
+        date = '2020-02-27T21:26:01.123456'
         _date = parse_date_iso_format(date)
-        eq_(_date, '2020-07-07T20:15:59.642761')
+        eq_(_date, '2020-02-27T21:26:01.123456')
+
+    def test_iso_date(self):
+        date = '2020-09-25'
+        _date = parse_date_iso_format(date)
+        eq_(_date, '2020-09-25T00:00:00')
+
+    def test_iso_datetime_stripped(self):
+        date = '20200925T104941'
+        _date = parse_date_iso_format(date)
+        eq_(_date, '2020-09-25T10:49:41')
+
+    def test_date_with_slash(self):
+        date = '2020/09/25'
+        _date = parse_date_iso_format(date)
+        eq_(_date, '2020-09-25T00:00:00')

--- a/ckanext/dcat/tests/test_utils.py
+++ b/ckanext/dcat/tests/test_utils.py
@@ -1,6 +1,7 @@
 import nose
 
 from ckanext.dcat.utils import parse_accept_header
+from ckanext.dcat.utils import parse_date_iso_format
 
 eq_ = nose.tools.eq_
 
@@ -126,3 +127,21 @@ class TestAcceptHeaders(object):
         _format = parse_accept_header(header)
 
         eq_(_format, None)
+
+
+class TestDateIsoFormat(object):
+
+    def test_empty(self):
+        date = ''
+        _date = parse_date_iso_format(date)
+        eq_(_date, None)
+
+    def test_date(self):
+        date = '2020-07-07'
+        _date = parse_date_iso_format(date)
+        eq_(_date, '2020-07-07T00:00:00')
+
+    def test_datetime(self):
+        date = '2020-07-07T20:15:59.642761'
+        _date = parse_date_iso_format(date)
+        eq_(_date, '2020-07-07T20:15:59.642761')

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -3,6 +3,7 @@ import uuid
 import json
 import datetime
 from dateutil.parser import parse as parse_date
+from dateutil.parser import ParserError
 
 from ckantoolkit import config, h
 
@@ -350,5 +351,5 @@ def parse_date_iso_format(date):
         default_datetime = datetime.datetime(2000, 1, 1, 0, 0, 0)
         _date = parse_date(date, default=default_datetime)
         return _date.isoformat()
-    except:
+    except (AttributeError, ParserError):
         return None

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -289,6 +289,10 @@ import operator
 accept_re = re.compile("^(?P<ct>[^;]+)[ \t]*(;[ \t]*q=(?P<q>[0-9.]+)){0,1}$")
 
 
+def check_if_date_is_iso_format(date):
+    pattern = '^([0-9]{4})-([0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z)$'
+    return re.findall(pattern, date)
+
 def parse_accept_header(accept_header=''):
     '''
     Parses the supplied accept header and tries to determine

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -1,6 +1,8 @@
 import logging
 import uuid
 import json
+import datetime
+from dateutil.parser import parse as parse_date
 
 from ckantoolkit import config, h
 
@@ -289,10 +291,6 @@ import operator
 accept_re = re.compile("^(?P<ct>[^;]+)[ \t]*(;[ \t]*q=(?P<q>[0-9.]+)){0,1}$")
 
 
-def check_if_date_is_iso_format(date):
-    pattern = '^([0-9]{4})-([0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z)$'
-    return re.findall(pattern, date)
-
 def parse_accept_header(accept_header=''):
     '''
     Parses the supplied accept header and tries to determine
@@ -341,3 +339,16 @@ def parse_accept_header(accept_header=''):
                 return accepted_media_types_wildcard[_type]
 
     return None
+
+
+def parse_date_iso_format(date):
+    '''
+    Parses the supplied date and tries to return it as a string in iso format
+    '''
+    try:
+        date = date.replace('Z', '')
+        default_datetime = datetime.datetime(2000, 1, 1, 0, 0, 0)
+        _date = parse_date(date, default=default_datetime)
+        return _date.isoformat()
+    except:
+        return None


### PR DESCRIPTION
## [TICKET](https://opengovinc.atlassian.net/browse/PERF-962)

## Description
<!--- Describe these changes in detail --->
This PR updates logic that occurs before a harvested dataset is indexed in Solr.
Note that the indexed last modified timestamp is changed, but not the dataset's last modified timestamp. This means that a harvested dataset will display the timestamp when it was harvested into CKAN, but will be ordered in the dataset search pages by the indexed upstream timestamp.

## Test Procedure
Requirements:
- The ckanext-harvest extension is installed
- The ckanext-dcat extension is installed
- Setup `/usr/lib/ckan/default/src/ckan/test-core.ini` with test DB config, [Testing CKAN](https://docs.ckan.org/en/2.7/contributing/test.html)

Install Instructions:
- Checkout PR branch in ckanext-dcat
```
cd /usr/lib/ckan/default/src/ckanext-dcat
git checkout dvasilov/PERF-962/11-08-2020/check-timestamp
```
- Ensure plugin list is configured correctly in CKAN ini config file
```
ckan.plugins = stats resource_proxy viewhelpers ags_fs_view ags_ms_view barchart basicgrid linechart piechart
  geo_view geojson_view c3charts datatables_view image_view officedocs_view pdf_view webpage_view
  odata datastore xloader extractor harvest datajson dcat dcat_rdf_harvester
  dcat_json_harvester dcat_json_interface structured_data opengov_harvester
  contact pages showcase theme_configurator og_theme security heroslideradmin
```
- Restart supervisor service for gather and fetch harvest queue
```
sudo service supervisor restart
```
- Restart CKAN in either terminal or apache
```
sudo service apache2 restart
```

Testing:
- Run nosetest
```
cd /usr/lib/ckan/default/src/ckanext-dcat
nosetests --ckan --with-pylons=test.ini ckanext/dcat/tests
```
- Create dcat json harvester job in CKAN UI for https://cdph-chhsagency.opendata.arcgis.com/data.json. After harvest job is complete the order of datasets on the dataset search page should be the same as the upstream source.