### PR TITLE
Trigger xloader on dcat_modified change

### DIFF
--- a/ckanext/dcat/tests/test_utils.py
+++ b/ckanext/dcat/tests/test_utils.py
@@ -1,5 +1,9 @@
 from ckanext.dcat.utils import parse_accept_header
-from ckanext.dcat.utils import parse_date_iso_format
+from ckanext.dcat.utils import (
+    parse_date_iso_format,
+    is_xloader_format,
+    is_dcat_modified_field_changed
+)
 
 
 def test_accept_header_empty():
@@ -125,7 +129,7 @@ def test_accept_header_html_multiple():
 
 class TestDateIsoFormat(object):
 
-    def test_empty(self):
+    def test_empty_date(self):
         date = ''
         _date = parse_date_iso_format(date)
         assert _date is None
@@ -154,3 +158,119 @@ class TestDateIsoFormat(object):
         date = '2020/09/25'
         _date = parse_date_iso_format(date)
         assert _date == '2020-09-25T00:00:00'
+
+
+class TestIsXloaderFormat(object):
+
+    def test_empty_format(self):
+        resource_format = ''
+        xloader_format = is_xloader_format(resource_format)
+        assert not xloader_format
+
+    def test_csv_format(self):
+        resource_format = 'csv'
+        xloader_format = is_xloader_format(resource_format)
+        assert xloader_format
+
+    def test_xls_format(self):
+        resource_format = 'xls'
+        xloader_format = is_xloader_format(resource_format)
+        assert xloader_format
+
+
+class TestIsDcatModifiedFieldChanged(object):
+    def test_empty_old_package_dict(self):
+        old_package_dict = {}
+        new_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2021-03-01T10:10:45.123456"
+                }
+            ]
+        }
+        changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
+        assert changed_dcat_modified
+
+    def test_empty_new_package_dict(self):
+        old_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2020-12-01T09:18:30.908070"
+                }
+            ]
+        }
+        new_package_dict = {}
+        changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
+        assert changed_dcat_modified
+
+    def test_missinng_dcat_modified_in_new_package_dict(self):
+        old_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2020-12-01T09:18:30.908070"
+                }
+            ]
+        }
+        new_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset"
+        }
+        changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
+        assert changed_dcat_modified
+
+    def test_changed_dcat_modified(self):
+        old_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2020-12-01T09:18:30.908070"
+                }
+            ]
+        }
+        new_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2021-03-01T10:10:45.123456"
+                }
+            ]
+        }
+        changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
+        assert changed_dcat_modified
+
+    def test_same_dcat_modified(self):
+        old_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2021-03-01T10:10:45.123456"
+                }
+            ]
+        }
+        new_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2021-03-01T10:10:45.123456"
+                }
+            ]
+        }
+        changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
+        assert not changed_dcat_modified

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -514,3 +514,43 @@ def parse_date_iso_format(date):
     except Exception:
         pass
     return None
+
+
+def is_xloader_format(resource_format):
+    '''
+    Determines if the supplied format is accepted by ckanext-xloader
+    '''
+    DEFAULT_FORMATS = [
+        'csv', 'application/csv',
+        'xls', 'xlsx', 'tsv',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'ods', 'application/vnd.oasis.opendocument.spreadsheet',
+    ]
+    xloader_formats = config.get('ckanext.xloader.formats')
+    if xloader_formats is not None:
+        xloader_formats = xloader_formats.lower().split()
+    else:
+        xloader_formats = DEFAULT_FORMATS
+    if not resource_format:
+        return False
+    return resource_format.lower() in xloader_formats
+
+
+def is_dcat_modified_field_changed(old_package_dict, new_package_dict):
+    '''
+    Determines if dcat_modified field has changed
+    '''
+    old_dcat_modified = ''
+    new_dcat_modified = ''
+    for extra in old_package_dict.get('extras', {}):
+        if extra.get('key') == 'dcat_modified':
+            old_dcat_modified = extra.get('value')
+            break
+    for extra in new_package_dict.get('extras', {}):
+        if extra.get('key') == 'dcat_modified':
+            new_dcat_modified = extra.get('value')
+            break
+    if old_dcat_modified != new_dcat_modified:
+        return True
+    return False


### PR DESCRIPTION
This PR adds a feature to submit a dataset's resources to xloader when the dataset's previous and current dcat_modified are different. Only resources with a xloader format (i.e. CSV) will be submitted.