### PR TITLE
Don't trigger xloader submission if old or new package dict is empty or null

### DIFF
--- a/ckanext/dcat/tests/test_utils.py
+++ b/ckanext/dcat/tests/test_utils.py
@@ -192,7 +192,7 @@ class TestIsDcatModifiedFieldChanged(object):
             ]
         }
         changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
-        assert changed_dcat_modified
+        assert not changed_dcat_modified
 
     def test_empty_new_package_dict(self):
         old_package_dict = {
@@ -207,7 +207,37 @@ class TestIsDcatModifiedFieldChanged(object):
         }
         new_package_dict = {}
         changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
-        assert changed_dcat_modified
+        assert not changed_dcat_modified
+
+    def test_null_old_package_dict(self):
+        old_package_dict = None
+        new_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2021-03-01T10:10:45.123456"
+                }
+            ]
+        }
+        changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
+        assert not changed_dcat_modified
+
+    def test_null_new_package_dict(self):
+        old_package_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2020-12-01T09:18:30.908070"
+                }
+            ]
+        }
+        new_package_dict = None
+        changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
+        assert not changed_dcat_modified
 
     def test_missinng_dcat_modified_in_new_package_dict(self):
         old_package_dict = {

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -543,6 +543,8 @@ def is_dcat_modified_field_changed(old_package_dict, new_package_dict):
     '''
     old_dcat_modified = ''
     new_dcat_modified = ''
+    if not old_package_dict or not new_package_dict:
+        return False
     for extra in old_package_dict.get('extras', {}):
         if extra.get('key') == 'dcat_modified':
             old_dcat_modified = extra.get('value')


### PR DESCRIPTION
This PR updates the logic to compare the `dcat_modified` field in the previous and newly harvested package.
Now if either old or new package dictionary is empty or null the function `is_dcat_modified_field_changed()` will return false. In this case the package resources will not be xloader submission.