### PR TITLE
Handle exceptions for private datasets

### DIFF
--- a/ckanext/dcat/logic.py
+++ b/ckanext/dcat/logic.py
@@ -21,7 +21,12 @@ def dcat_dataset_show(context, data_dict):
 
     toolkit.check_access('dcat_dataset_show', context, data_dict)
 
-    dataset_dict = toolkit.get_action('package_show')(context, data_dict)
+    try:
+        dataset_dict = toolkit.get_action('package_show')(context, data_dict)
+    except toolkit.ValidationError as error:
+        return toolkit.abort(400, error.message)
+    except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
+        return toolkit.abort(404, toolkit._('Package not found'))
 
     serializer = RDFSerializer(profiles=data_dict.get('profiles'))
 


### PR DESCRIPTION
## Description
This PR updates the logic used in the `dcat_dataset_show` function for RDF serialization.
A server error occurs when a user tries to access a private dataset in different RDF serialization formats like XML.

This fix this issue we should return a 400 or 404 error on exceptions like `NotAuthorized`.