### PR TITLE
Add support for ckanext-fluent fields

### DIFF
--- a/ckanext/dcat/configuration_processors.py
+++ b/ckanext/dcat/configuration_processors.py
@@ -226,15 +226,27 @@ class MappingFields(BaseConfigProcessor):
                 # If configured convert timestamp to separate date and time formats
                 if dcat_dict.get('issued'):
                     if map_field.get('source') == 'issued_date':
-                        value = datetime.strptime(dcat_dict.get('issued'), '%Y-%m-%dT%H:%M:%S.%fZ').strftime('%Y-%m-%d')
+                        value = datetime.strptime(
+                            dcat_dict.get('issued'),
+                            '%Y-%m-%dT%H:%M:%S.%fZ'
+                        ).strftime('%Y-%m-%d')
                     if map_field.get('source') == 'issued_time':
-                        value = datetime.strptime(dcat_dict.get('issued'), '%Y-%m-%dT%H:%M:%S.%fZ').strftime('%H:%M:%S.%fZ')
+                        value = datetime.strptime(
+                            dcat_dict.get('issued'),
+                            '%Y-%m-%dT%H:%M:%S.%fZ'
+                        ).strftime('%H:%M:%S.%fZ')
 
                 if dcat_dict.get('modified'):
                     if map_field.get('source') == 'modified_date':
-                        value = datetime.strptime(dcat_dict.get('modified'), '%Y-%m-%dT%H:%M:%S.%fZ').strftime('%Y-%m-%d')
+                        value = datetime.strptime(
+                            dcat_dict.get('modified'),
+                            '%Y-%m-%dT%H:%M:%S.%fZ'
+                        ).strftime('%Y-%m-%d')
                     if map_field.get('source') == 'modified_time':
-                        value = datetime.strptime(dcat_dict.get('modified'), '%Y-%m-%dT%H:%M:%S.%fZ').strftime('%H:%M:%S.%fZ')
+                        value = datetime.strptime(
+                            dcat_dict.get('modified'),
+                            '%Y-%m-%dT%H:%M:%S.%fZ'
+                        ).strftime('%H:%M:%S.%fZ')
 
                 # Map value to dataset field
                 package_dict[target_field] = value

--- a/ckanext/dcat/tests/test_configuration_processors.py
+++ b/ckanext/dcat/tests/test_configuration_processors.py
@@ -302,6 +302,97 @@ class TestMappingFields:
 
         assert package["language"] == "Spanish"
 
+    def test_modify_package_mapping_values_with_issued_date(self):
+        package = {
+            "title": "Test Dataset",
+            "name": "test-dataset"
+        }
+        config = {
+            "map_fields": [
+                {
+                    "source": "issued_date",
+                    "target": "issued_date"
+                }
+            ]
+        }
+        dcat_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "issued": "2021-08-01T20:05:31.000Z"
+        }
+
+        self.processor.modify_package_dict(package, config, dcat_dict)
+
+        assert package["issued_date"] == "2021-08-01"
+
+    def test_modify_package_mapping_values_with_issued_time(self):
+        package = {
+            "title": "Test Dataset 1",
+            "name": "test-dataset-1"
+        }
+        config = {
+            "map_fields": [
+                {
+                    "source": "issued_time",
+                    "target": "issued_time"
+                }
+            ]
+        }
+        dcat_dict = {
+            "title": "Test Dataset-1",
+            "name": "test-dataset-1",
+            "issued": "2021-08-01T20:05:31.000Z"
+        }
+
+        self.processor.modify_package_dict(package, config, dcat_dict)
+
+        assert package["issued_time"] == "20:05:31.000000Z"
+
+    def test_modify_package_mapping_values_with_modified_date(self):
+        package = {
+            "title": "Test Dataset",
+            "name": "test-dataset"
+        }
+        config = {
+            "map_fields": [
+                {
+                    "source": "modified_date",
+                    "target": "modified_date"
+                }
+            ]
+        }
+        dcat_dict = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "modified": "2022-08-31T11:16:25.000Z"
+        }
+
+        self.processor.modify_package_dict(package, config, dcat_dict)
+
+        assert package["modified_date"] == "2022-08-31"
+
+    def test_modify_package_mapping_values_with_modified_time(self):
+        package = {
+            "title": "Test Dataset 1",
+            "name": "test-dataset-1"
+        }
+        config = {
+            "map_fields": [
+                {
+                    "source": "modified_time",
+                    "target": "modified_time"
+                }
+            ]
+        }
+        dcat_dict = {
+            "title": "Test Dataset-1",
+            "name": "test-dataset-1",
+            "modified": "2022-08-31T11:16:25.000Z"
+        }
+
+        self.processor.modify_package_dict(package, config, dcat_dict)
+
+        assert package["modified_time"] == "11:16:25.000Z"
 
 class TestPublisher:
 

--- a/ckanext/dcat/tests/test_configuration_processors.py
+++ b/ckanext/dcat/tests/test_configuration_processors.py
@@ -392,7 +392,7 @@ class TestMappingFields:
 
         self.processor.modify_package_dict(package, config, dcat_dict)
 
-        assert package["modified_time"] == "11:16:25.000Z"
+        assert package["modified_time"] == "11:16:25.000000Z"
 
 class TestPublisher:
 


### PR DESCRIPTION
## Description
This PR adds support for the following ckanext-fluent fields:
- title_translated
- notes_translated
- name_translated
- description_translated

Also add support to map issued and modified dates to custom fields