### PR TITLE
Only check for url when keeping existing resources, names are not required

### DIFF
--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -405,7 +405,7 @@ def copy_across_resource_ids(existing_dataset, harvested_dataset, config=None):
         keep_existing_resources = config.get('keep_existing_resources', False)
         if keep_existing_resources and harvested_dataset.get('resources'):
             for existing_resource in existing_resources_still_to_match:
-                if existing_resource.get('name') and existing_resource.get('url'):
+                if existing_resource.get('url'):
                     harvested_dataset['resources'].append(existing_resource)
     except:
         pass


### PR DESCRIPTION
## Description
Only check for url when keeping existing resources.
There's an issue when a resource does not have the name field set since it is not a required field in the schema.