### PR TITLE
Fix parsing spatial field

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
@@ -16,7 +16,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8, 2.7]
+        ckan-version: ["2.10", 2.9, 2.8, 2.7]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
@@ -59,18 +59,22 @@ jobs:
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
+    - name: Setup extension (CKAN >= 2.9)
+      if: ${{ matrix.ckan-version != '2.7' && matrix.ckan-version != '2.8' }}
+      run: |
         # Install ckanext-harvest
         git clone https://github.com/ckan/ckanext-harvest
         pip install -e ckanext-harvest
         pip install -r ckanext-harvest/pip-requirements.txt
-    - name: Setup extension (CKAN >= 2.9)
-      if: ${{ matrix.ckan-version != '2.7' && matrix.ckan-version != '2.8' }}
-      run: |
         ckan -c test.ini db init
         ckan -c test.ini harvester initdb
     - name: Setup extension (CKAN < 2.9)
       if: ${{ matrix.ckan-version == '2.7' || matrix.ckan-version == '2.8' }}
       run: |
+        # Install ckanext-harvest version that supports 2.7
+        git clone https://github.com/ckan/ckanext-harvest -b v1.4.2
+        pip install -e ckanext-harvest
+        pip install -r ckanext-harvest/pip-requirements.txt
         paster --plugin=ckan db init -c test.ini
         paster --plugin=ckanext-harvest harvester initdb -c test.ini
     - name: Run tests

--- a/ckanext/dcat/tests/test_converters.py
+++ b/ckanext/dcat/tests/test_converters.py
@@ -47,3 +47,38 @@ def test_dcat_to_ckan():
 
     assert ckan_dict == expected_ckan_dict,_poor_mans_dict_diff(
         expected_ckan_dict, ckan_dict)
+
+def test_get_bbox_geojson():
+    spatial_string = '-124.4820,32.5288,-114.1312,42.0095'
+    bbox_geojson_1 = converters.get_bbox_geojson(spatial_string)
+    assert bbox_geojson_1 == ('{"type": "Polygon", "coordinates": [['
+        '[-124.4820,32.5288],[-124.4820,42.0095],'
+        '[-114.1312,42.0095],[-114.1312,32.5288],'
+        '[-124.4820,32.5288]]]}'
+    )
+
+    spatial_envelope = {
+        "type": "envelope",
+        "coordinates": [[-124.1986, 32.5586], [-71.3508, 47.299 ]]
+    }
+    bbox_geojson_2 = converters.get_bbox_geojson(spatial_envelope)
+    assert bbox_geojson_2 == ('{"type": "Polygon", "coordinates": [['
+        '[-124.1986,32.5586],[-124.1986,47.299],'
+        '[-71.3508,47.299],[-71.3508,32.5586],'
+        '[-124.1986,32.5586]]]}'
+    )
+
+    spatial_polygon = {
+        "type": "Polygon",
+        "coordinates": [[
+            [-124.1610, 32.5718], [-124.1610, 41.3149],
+            [-115.5028, 41.3149], [-115.5028, 32.5718],
+            [-124.1610, 32.5718]
+        ]]
+    }
+    bbox_geojson_3 = converters.get_bbox_geojson(spatial_polygon)
+    assert bbox_geojson_3 == ('{"type": "Polygon", "coordinates": [['
+        '[-124.161, 32.5718], [-124.161, 41.3149], '
+        '[-115.5028, 41.3149], [-115.5028, 32.5718], '
+        '[-124.161, 32.5718]]]}'
+    )


### PR DESCRIPTION
## Description
Improve parsing of spatial field. An error occurs if the spatial field is not a string.
```
  File "/src/ckanext-dcat/ckanext/dcat/harvesters/_json.py", line 85, in _get_package_dict
    package_dict = converters.dcat_to_ckan(dcat_dict)
  File "/src/ckanext-dcat/ckanext/dcat/converters.py", line 43, in dcat_to_ckan
    bbox = dcat_dict.get('spatial','').split(',')
AttributeError: 'dict' object has no attribute 'split'
```

Previously it was assumed that the spatial field was a string. Now we check if it's a string or dictionary.

Also update GitHub Action test to install a version of ckanext-harvest that supports ckan 2.7 for now. 