### PR TITLE
Add parse id option

### DIFF
--- a/ckanext/dcat/configuration_processors.py
+++ b/ckanext/dcat/configuration_processors.py
@@ -49,6 +49,19 @@ class BaseConfigProcessor:
         raise NotImplementedError
 
 
+class ParseID(BaseConfigProcessor):
+
+    @staticmethod
+    def check_config(config_obj):
+        if 'parse_id_if_url' in config_obj:
+            if not isinstance(config_obj['parse_id_if_url'], bool):
+                raise ValueError('parse_id_if_url must be boolean')
+
+    @staticmethod
+    def modify_package_dict(package_dict, config, dcat_dict):
+        pass
+
+
 class DefaultTags(BaseConfigProcessor):
 
     @staticmethod

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -1,4 +1,3 @@
-import six
 from builtins import str
 from past.builtins import basestring
 import json
@@ -71,13 +70,10 @@ class DCATJSONHarvester(DCATHarvester):
 
             # Get identifier
             guid = dataset.get('identifier')
-            try:
-                parsed_url = six.moves.urllib.parse.urlparse(guid)
-                parsed_query = six.moves.urllib.parse.parse_qs(parsed_url.query)
-                if parsed_query.get('id'):
-                    guid = parsed_query.get('id')[0]
-            except Exception:
-                guid = dataset.get('identifier')
+
+            if self.config.get('parse_id_if_url'):
+                # Get id from identifier if it is a url
+                guid = utils.parse_identifier(dataset.get('identifier'))
 
             if not guid:
                 # This is bad, any ideas welcomed

--- a/ckanext/dcat/tests/test_configuration_processors.py
+++ b/ckanext/dcat/tests/test_configuration_processors.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from ckanext.dcat.configuration_processors import (
+    ParseID,
     DefaultTags, CleanTags,
     DefaultGroups, DefaultExtras, DefaultValues,
     MappingFields, Publisher, ContactPoint,
@@ -9,6 +10,39 @@ from ckanext.dcat.configuration_processors import (
     ResourceFormatOrder,
     KeepExistingResources
 )
+
+
+class TestParseID:
+
+    processor = ParseID
+
+    def test_validation_correct_format(self):
+        config = {
+            "parse_id_if_url": True
+        }
+        try:
+            self.processor.check_config(config)
+        except ValueError:
+            assert False
+
+    def test_validation_wrong_format(self):
+        empty_config = {
+            "parse_id_if_url": ""
+        }
+        try:
+            self.processor.check_config(empty_config)
+            assert False
+        except ValueError:
+            assert True
+
+        string_config = {
+            "parse_id_if_url": "enabled"
+        }
+        try:
+            self.processor.check_config(string_config)
+            assert False
+        except ValueError:
+            assert True
 
 
 class TestDefaultTags:

--- a/ckanext/dcat/tests/test_utils.py
+++ b/ckanext/dcat/tests/test_utils.py
@@ -2,7 +2,8 @@ from ckanext.dcat.utils import parse_accept_header
 from ckanext.dcat.utils import (
     parse_date_iso_format,
     is_xloader_format,
-    is_dcat_modified_field_changed
+    is_dcat_modified_field_changed,
+    parse_identifier
 )
 
 
@@ -304,3 +305,37 @@ class TestIsDcatModifiedFieldChanged(object):
         }
         changed_dcat_modified = is_dcat_modified_field_changed(old_package_dict, new_package_dict)
         assert not changed_dcat_modified
+
+
+class TestParseID(object):
+    def test_parse_id_in_url_found(self):
+        dataset_1 = {
+            'identifier': 'http://example.com/item.html?id=someid&sublayer=0',
+            'title': 'Dataset 1'
+        }
+        guid_1 = parse_identifier(dataset_1.get('identifier'))
+        assert guid_1 == 'someid'
+
+    def test_parse_id_in_url_null(self):
+        dataset_2 = {
+            'identifier': 'http://example.com/item.html?id=null&sublayer=0',
+            'title': 'Dataset 2'
+        }
+        guid_2 = parse_identifier(dataset_2.get('identifier'))
+        assert guid_2 == 'null'
+
+    def test_parse_id_in_url_none(self):
+        dataset_3 = {
+            'identifier': 'http://example.com/item.html?id=none&sublayer=0',
+            'title': 'Dataset 3'
+        }
+        guid_3 = parse_identifier(dataset_3.get('identifier'))
+        assert guid_3 == 'none'
+
+    def test_parse_id_in_url_not_found(self):
+        dataset_4 = {
+            'identifier': 'http://example.com/item.html?id=&sublayer=0',
+            'title': 'Dataset 4'
+        }
+        guid_4 = parse_identifier(dataset_4.get('identifier'))
+        assert guid_4 == 'http://example.com/item.html?id=&sublayer=0'

--- a/ckanext/dcat/utils.py
+++ b/ckanext/dcat/utils.py
@@ -6,6 +6,7 @@ import uuid
 import simplejson as json
 import re
 import operator
+import six
 
 import datetime
 from dateutil.parser import parse as parse_date
@@ -540,3 +541,18 @@ def is_dcat_modified_field_changed(old_package_dict, new_package_dict):
     if old_dcat_modified != new_dcat_modified:
         return True
     return False
+
+
+def parse_identifier(identifier):
+    '''
+    Parse identifier as a url and get id
+    '''
+    guid = identifier
+    try:
+        parsed_url = six.moves.urllib.parse.urlparse(identifier)
+        parsed_query = six.moves.urllib.parse.parse_qs(parsed_url.query)
+        if parsed_query.get('id'):
+            guid = parsed_query.get('id')[0]
+    except Exception:
+        guid = identifier
+    return guid


### PR DESCRIPTION
## Description
Add dcat json harvester option, `parse_id_if_url`.
If set to true the harvester will parse the dataset identifier to get id parameter if it's a url. (i.e. https://www.arcgis.com/home/item.html?id=4eac545ab76a4920ae4fb8ed67c19bd6&sublayer=41)