### PR TITLE
Add upload to datastore option

### DIFF
--- a/ckanext/dcat/configuration_processors.py
+++ b/ckanext/dcat/configuration_processors.py
@@ -399,3 +399,16 @@ class KeepExistingResources(BaseConfigProcessor):
     @staticmethod
     def modify_package_dict(package_dict, config, dcat_dict):
         pass
+
+
+class UploadToDatastore(BaseConfigProcessor):
+
+    @staticmethod
+    def check_config(config_obj):
+        if 'upload_to_datastore' in config_obj:
+            if not isinstance(config_obj.get('upload_to_datastore'), bool):
+                raise ValueError('upload_to_datastore must be boolean')
+
+    @staticmethod
+    def modify_package_dict(package_dict, config, dcat_dict):
+        pass

--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -23,7 +23,8 @@ from ckanext.dcat.configuration_processors import (
     MappingFields, Publisher, ContactPoint,
     OrganizationFilter,
     ResourceFormatOrder,
-    KeepExistingResources
+    KeepExistingResources,
+    UploadToDatastore
 )
 
 
@@ -49,7 +50,8 @@ class DCATHarvester(HarvesterBase):
         ContactPoint,
         OrganizationFilter,
         ResourceFormatOrder,
-        KeepExistingResources
+        KeepExistingResources,
+        UploadToDatastore
     ]
 
     def _get_content_and_type(self, url, harvest_job, page=1,

--- a/ckanext/dcat/tests/test_configuration_processors.py
+++ b/ckanext/dcat/tests/test_configuration_processors.py
@@ -8,7 +8,8 @@ from ckanext.dcat.configuration_processors import (
     MappingFields, Publisher, ContactPoint,
     OrganizationFilter,
     ResourceFormatOrder,
-    KeepExistingResources
+    KeepExistingResources,
+    UploadToDatastore
 )
 
 
@@ -823,6 +824,30 @@ class TestKeepExistingResources:
     def test_validation_wrong_format(self):
         config = {
             "keep_existing_resources": "true"
+        }
+        try:
+            self.processor.check_config(config)
+            assert False
+        except ValueError:
+            assert True
+
+
+class UploadToDatastore:
+
+    processor = UploadToDatastore
+
+    def test_validation_correct_format(self):
+        config = {
+            "upload_to_datastore": True
+        }
+        try:
+            self.processor.check_config(config)
+        except ValueError:
+            assert False
+
+    def test_validation_wrong_format(self):
+        config = {
+            "upload_to_datastore": "true"
         }
         try:
             self.processor.check_config(config)


### PR DESCRIPTION
## Description
Add harvest config option to check if tabular resources should be uploaded to the datastore.
By default this is set to true.