### PR TITLE
Add CompositeMapping

### DIFF
--- a/ckanext/dcat/configuration_processors.py
+++ b/ckanext/dcat/configuration_processors.py
@@ -284,8 +284,6 @@ class CompositeMapping(BaseConfigProcessor):
     @staticmethod
     def check_config(config_obj):
         if 'composite_field_mapping' in config_obj:
-            if 'composite' not in p.toolkit.g.plugins:
-                raise ValueError('The composite extension is not enabled')
             if not isinstance(config_obj['composite_field_mapping'], list):
                 raise ValueError('composite_field_mapping must be a *list* of dictionaries')
             if config_obj['composite_field_mapping'] and not isinstance(config_obj['composite_field_mapping'][0], dict):

--- a/ckanext/dcat/harvesters/base.py
+++ b/ckanext/dcat/harvesters/base.py
@@ -20,7 +20,8 @@ from ckan.lib.helpers import json
 from ckanext.dcat.configuration_processors import (
     DefaultTags, CleanTags,
     DefaultGroups, DefaultExtras, DefaultValues,
-    MappingFields, Publisher, ContactPoint,
+    MappingFields, CompositeMapping, Publisher,
+    ContactPoint,
     OrganizationFilter,
     ResourceFormatOrder,
     KeepExistingResources
@@ -45,6 +46,7 @@ class DCATHarvester(HarvesterBase):
         DefaultExtras,
         DefaultValues,
         MappingFields,
+        CompositeMapping,
         Publisher,
         ContactPoint,
         OrganizationFilter,

--- a/ckanext/dcat/tests/test_configuration_processors.py
+++ b/ckanext/dcat/tests/test_configuration_processors.py
@@ -5,7 +5,8 @@ from ckanext.dcat.configuration_processors import (
     ParseID,
     DefaultTags, CleanTags,
     DefaultGroups, DefaultExtras, DefaultValues,
-    MappingFields, Publisher, ContactPoint,
+    MappingFields, CompositeMapping,
+    Publisher, ContactPoint,
     OrganizationFilter,
     ResourceFormatOrder,
     KeepExistingResources
@@ -530,6 +531,37 @@ class TestMappingFields:
         self.processor.modify_package_dict(package, config, dcat_dict)
 
         assert package["modified_time"] == "11:16:25.000000Z"
+
+
+class TestCompositeMapping:
+
+    processor = CompositeMapping
+
+    def test_modify_package(self):
+        package = {
+            "title": "Test Dataset 1",
+            "name": "test-dataset-1"
+        }
+
+        config = {
+            "composite_field_mapping": [
+                {
+                    "idInfoCitation": {
+                        "publicationDate": "metadataReviseDate"
+                    }
+                }
+            ]
+        }
+        dcat_dict = {
+            "title": "Test Dataset-1",
+            "name": "test-dataset-1",
+            "metadataReviseDate": "2023-01-01T18:35:34.000Z"
+        }
+
+        self.processor.modify_package_dict(package, config, dcat_dict)
+
+        assert package["idInfoCitation"] == "{\"publicationDate\": \"2023-01-01T18:35:34.000Z\"}"
+
 
 class TestPublisher:
 


### PR DESCRIPTION
## Description
Add capability to map from dcat field to a subfield within a composite field.
The harvest config will look like the following:
```
    "composite_field_mapping": [
        {
            "idInfoCitation": {
                "publicationDate": "metadataReviseDate"
            }
        }
    ]
```
where `idInfoCitation` is the composite field, `publicationDate` is the subfield and `metadataReviseDate` is the field from the harvest source