### PR TITLE
Handle accessURL as a list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,10 @@ jobs:
         git clone https://github.com/OpenGov-OpenData/ckanext-scheming
         pip install -e ckanext-scheming
         git clone https://github.com/ckan/ckanext-fluent
+        # Checkout a specific commit that works with ckan 2.9
+        cd ckanext-fluent
+        git checkout 4e9340a934050e937bed49e6009d0971d880410a
+        cd ..
         pip install -e ckanext-fluent
     - name: Setup extension
       run: |

--- a/ckanext/dcat/harvesters/_json.py
+++ b/ckanext/dcat/harvesters/_json.py
@@ -482,7 +482,10 @@ def push_data_dictionary(context, resource, distribution):
     # Check for resource's data dictionary in the distribution
     fields = []
     for dist in distribution:
-        if ((dist.get('downloadURL') == resource.get('url') or dist.get('accessURL') == resource.get('url'))
+        # Normalize URLs for comparison
+        download_url = converters._normalize_url_value(dist.get('downloadURL'), 'downloadURL')
+        access_url = converters._normalize_url_value(dist.get('accessURL'), 'accessURL')
+        if ((download_url == resource.get('url') or access_url == resource.get('url'))
                 and dist.get('title') == resource.get('name')
                 and 'action/datastore_search' in dist.get('describedBy', '')):
             try:

--- a/ckanext/dcat/tests/test_converters.py
+++ b/ckanext/dcat/tests/test_converters.py
@@ -82,3 +82,15 @@ def test_get_bbox_geojson():
         '[-115.5028, 41.3149], [-115.5028, 32.5718], '
         '[-124.161, 32.5718]]]}'
     )
+
+def test_normalize_url_value_with_list():
+    value = [
+        "withheld",
+        "withheld",
+        "https://www.wildlife.ca.gov/Data/BIOS",
+        "https://services2.arcgis.com/Uq9r85Potqm3MfRV/arcgis/rest/services/biosds69_fmu/FeatureServer",
+        "http://dx.doi.org/doi:10.5066/F7X06527"
+    ]
+
+    result = converters._normalize_url_value(value, 'accessURL')
+    assert result == "https://www.wildlife.ca.gov/Data/BIOS"


### PR DESCRIPTION
# Description
According to the DCAT schema accessURL must be a single URL string (https://resources.data.gov/resources/dcat-us/#distribution-accessURL). However, some catalogs sometimes provide a list of URLs instead. We should handle this edge case by selecting the first URL that uses a supported protocol.

Here's an example distribution where the accessURL is a list:
```
{
  "@type": "dcat:Distribution",
  "title": "PAD Homepage",
  "format": null,
  "accessURL": [
    "withheld",
    "withheld",
    "https://www.wildlife.ca.gov/Data/BIOS",
    "https://services2.arcgis.com/Uq9r85Potqm3MfRV/arcgis/rest/services/biosds69_fmu/FeatureServer",
    "http://dx.doi.org/doi:10.5066/F7X06527"
  ],
  "description": null
}
```